### PR TITLE
テキストボックスが空白のみの場合アイテムを登録しない処理を追加

### DIFF
--- a/app/assets/javascripts/controllers/TodoListController.js
+++ b/app/assets/javascripts/controllers/TodoListController.js
@@ -4,11 +4,13 @@ angular.module('crazyTodoApp')
   
   //Todo追加
   $scope.addTodo = function(todoDescription) {
-    todo = { 'description' : todoDescription, 'completed' : false };
-    $scope.list.todos.unshift(todo);
-    $scope.todoDescription = '';
+    if ($scope.todoDescription) {
+      todo = { 'description' : todoDescription, 'completed' : false };
+      $scope.list.todos.unshift(todo);
+      $scope.todoDescription = '';
+    }
   };
-  //Todo完了
+
   //Todo削除
   $scope.deleteTodo = function(todo) {
     $scope.list.todos.splice($scope.list.todos.indexOf(todo), 1);

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -8,11 +8,10 @@
       <span>{{list.name}}</span>
     </div>
 
-    <form name="todoForm" id="new_todo" ng-submit="addTodo(todoDescription)">
+    <form id="new_todo" ng-submit="addTodo(todoDescription)">
       <div class="input-group">
-        <input type="text" name="todoDescription" id="todoDescription" class="form-control input-md" placeholder="Add a Todo..." 
-        autofocus="autofocus" maxlength="255" ng-model="todoDescription" required />
-        <span ng-show="todoForm.todoDescription.$error.required"></span>
+        <input type="text" id="todoDescription" class="form-control input-md" 
+        placeholder="Add a Todo..." autofocus="autofocus" maxlength="255" ng-model="todoDescription" />
         <button class="btn btn-info btn-md" type="submit">Add</button>
       </div>
     </form>


### PR DESCRIPTION
まずはじめに、
`addTodo()`が呼び出された時に、if文で`todoDescription`が空白でないかを判断する

```
if ($scope.todoDescription != '')
```

結果を見てみると、スペースのみだとアイテム登録はできなくなっているが、何も入力していない状態、つまり’'だとアイテム登録ができてしまう。

```
console.log($scope.todoDescription)
```

を使って、フォームに`''`を入力したときの`todoDesctiption`の中身を確認する。`undedified`が代入されていた。

javascriptにおいて`undedified != ''`である。
javascriptにおいて`undefined`も`''`も値の評価は`false`なので、

```
if ($scope.todoDescription)
```

とするとうまくいく。
