### PR TITLE
Requier validationを使って、テキストボックス何も入力されていない時は、アイテムを作成しない処理を実装。

### DIFF
--- a/app/assets/javascripts/controllers/TodoListController.js
+++ b/app/assets/javascripts/controllers/TodoListController.js
@@ -4,11 +4,13 @@ angular.module('crazyTodoApp')
   
   //Todo追加
   $scope.addTodo = function(todoDescription) {
-    todo = { 'description' : todoDescription, 'completed' : false };
-    $scope.list.todos.unshift(todo);
-    $scope.todoDescription = '';
+    if ($scope.todoDescription) {
+      todo = { 'description' : todoDescription, 'completed' : false };
+      $scope.list.todos.unshift(todo);
+      $scope.todoDescription = '';
+    }
   };
-  //Todo完了
+
   //Todo削除
   $scope.deleteTodo = function(todo) {
     $scope.list.todos.splice($scope.list.todos.indexOf(todo), 1);

--- a/app/assets/javascripts/controllers/TodoListController.js
+++ b/app/assets/javascripts/controllers/TodoListController.js
@@ -4,11 +4,11 @@ angular.module('crazyTodoApp')
   
   //Todo追加
   $scope.addTodo = function(todoDescription) {
-    if ($scope.todoDescription) {
+    //if ($scope.todoDescription) {
       todo = { 'description' : todoDescription, 'completed' : false };
       $scope.list.todos.unshift(todo);
       $scope.todoDescription = '';
-    }
+    //}
   };
 
   //Todo削除

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -8,11 +8,13 @@
       <span>{{list.name}}</span>
     </div>
 
-    <form id="new_todo" ng-submit="addTodo(todoDescription)">
+    <form name="new_todo" id="new_todo" ng-submit="addTodo(todoDescription)" novalidate>
       <div class="input-group">
-        <input type="text" id="todoDescription" class="form-control input-md" 
-        placeholder="Add a Todo..." autofocus="autofocus" maxlength="255" ng-model="todoDescription" />
-        <button class="btn btn-info btn-md" type="submit">Add</button>
+        <input type="text" name="todoDescription" id="todoDescription" class="form-control input-md" 
+        placeholder="Add a Todo..." autofocus="autofocus" autocomplete="off" maxlength="255" 
+        ng-model="todoDescription" required />
+        <!-- <span ng-show="new_todo.todoDescription.$error.required">hogehoge</span> -->
+        <button class="btn btn-info btn-md" type="submit" ng-disabled="new_todo.$invalid" >Add</button>
       </div>
     </form>
   

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -8,11 +8,10 @@
       <span>{{list.name}}</span>
     </div>
 
-    <form name="todoForm" id="new_todo" ng-submit="addTodo(todoDescription)">
+    <form id="new_todo" ng-submit="addTodo(todoDescription)">
       <div class="input-group">
-        <input type="text" name="todoDescription" id="todoDescription" class="form-control input-md" placeholder="Add a Todo..." 
-        autofocus="autofocus" maxlength="255" ng-model="todoDescription" required />
-        <span ng-show="todoForm.todoDescription.$error.required"></span>
+        <input type="text" id="todoDescription" class="form-control input-md" 
+        placeholder="Add a Todo..." autofocus="autofocus" maxlength="255" ng-model="todoDescription" />
         <button class="btn btn-info btn-md" type="submit">Add</button>
       </div>
     </form>


### PR DESCRIPTION
bug/#1では、スコープオブジェクトからaddTodo()を呼び出してから、入力された値を判定し、アイテムを作成するか否かを判断していたが、今回は、MVCモデルで言うViewの部分で検証を行い、テキストボックス何も入力されていない時は、アイテムを作成するためのaddTodoを呼び出すことをしない。

Formに入力されたデータを検証することをValidationと言う。今回はテキストボックスの必須性を検証するrequiredを使った。requiredはHTMLの属性だが、Anuglarはこれを認識し、フォームの必須性を検証する。

テンプレートにValidation機能を拡張したところで、addTodoを呼び出すことは可能である。inputのアクションとsubmitのアクションは互いに独立しているからである。ですから、Validationを使って、検証した結果が不正である場合、ng-disabledを有効にして、submitできないようにするとうまくいく。
